### PR TITLE
Improving TypeConverter implementation 

### DIFF
--- a/Umbraco.Inception/Converters/ConverterHelper.cs
+++ b/Umbraco.Inception/Converters/ConverterHelper.cs
@@ -1,21 +1,31 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Umbraco.Core;
-using Umbraco.Core.Services;
-using Umbraco.Web;
-
-namespace Umbraco.Inception.Converters
+﻿namespace Umbraco.Inception.Converters
 {
+    using Umbraco.Core;
+    using Umbraco.Core.Services;
+    using Umbraco.Web;
+
+    /// <summary>
+    /// The converter helper.
+    /// </summary>
     public static class ConverterHelper
     {
+        /// <summary>
+        /// Gets the current media service.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="IMediaService"/>.
+        /// </returns>
         public static IMediaService GetMediaService()
         {
             return ApplicationContext.Current.Services.MediaService;
         }
 
+        /// <summary>
+        /// Gets an <see cref="UmbracoHelper"/>.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="UmbracoHelper"/>.
+        /// </returns>
         public static UmbracoHelper GetUmbracoHelper()
         {
             return new UmbracoHelper(UmbracoContext.Current);

--- a/Umbraco.Inception/Converters/JsonConverter.cs
+++ b/Umbraco.Inception/Converters/JsonConverter.cs
@@ -1,59 +1,98 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Umbraco.Inception.Converters
+﻿namespace Umbraco.Inception.Converters
 {
+    using System;
+    using System.ComponentModel;
+    using Newtonsoft.Json;
+
     /// <summary>
-    /// Converts a json string to the object. Internally Json.Net is used so if you can serialize and deserialize your object with Newton's Json.Net than you are safe to use this Converter
+    /// Converts a Json string to and from the given type. Internally Json.Net is used so if you can serialize and deserialize your object with Newton's Json.Net than you are safe to use this Converter
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">The <see cref="T:System.Type"/> to convert to and from.</typeparam>
     public class JsonConverter<T> : TypeConverter
     {
+        /// <summary>
+        /// Returns whether this converter can convert an object of the given type to the type of this converter, using the specified context.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="sourceType">A <see cref="T:System.Type" /> that represents the type you want to convert from.</param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
-            return (sourceType == typeof(string));
+            if (sourceType == typeof(string))
+            {
+                return true;
+            }
+
+            // Always call the base to see if it can perform the conversion. 
+            return base.CanConvertFrom(context, sourceType);
         }
 
+        /// <summary>
+        /// Converts the given object to the type of this converter, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
         public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
         {
             string json = value as string;
             if (json != null)
             {
-                try
-                {
-                    T target = JsonConvert.DeserializeObject<T>(json);
-                    return target;
-                }
-                catch (Exception ex)
-                {
-                    throw ex;
-                }
-
+                T target = JsonConvert.DeserializeObject<T>(json);
+                return target;
             }
-            return null;
+
+            // Always call base, even if you can't convert. 
+            return base.ConvertFrom(context, culture, value);
         }
 
+        /// <summary>
+        /// Returns whether this converter can convert the object to the specified type, using the specified context.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="destinationType">A <see cref="T:System.Type" /> that represents the type you want to convert to.</param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
-            return (destinationType == typeof(T));
+            if (destinationType == typeof(T))
+            {
+                return true;
+            }
+
+            // Always call the base to see if it can perform the conversion. 
+            return base.CanConvertTo(context, destinationType);
         }
 
+        /// <summary>
+        /// Converts the given value object to the specified type, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">A <see cref="T:System.Globalization.CultureInfo" />. If null is passed, the current culture is assumed.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <param name="destinationType">The <see cref="T:System.Type" /> to convert the <paramref name="value" /> parameter to.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
         public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
         {
-            try
+            T target = (T)value;
+
+            // Ignore any warning here. 
+            // http://stackoverflow.com/questions/5340817/what-should-i-do-about-possible-compare-of-value-type-with-null
+            if (target != null)
             {
-                T target = (T)value;
                 return JsonConvert.SerializeObject(target);
             }
-            catch (Exception ex)
-            {
-                throw ex;
-            }
+
+            // Always call base, even if you can't convert. 
+            return base.ConvertTo(context, culture, value, destinationType);
         }
     }
 }

--- a/Umbraco.Inception/Converters/MediaIdConverter.cs
+++ b/Umbraco.Inception/Converters/MediaIdConverter.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Umbraco.Core.Models;
-using Umbraco.Core.Services;
-
-namespace Umbraco.Inception.Converters
+﻿namespace Umbraco.Inception.Converters
 {
+    using System;
+    using System.ComponentModel;
+    using Umbraco.Core.Models;
+    using Umbraco.Core.Services;
+    using Umbraco.Web;
+
     /// <summary>
     /// If you use the MediaPicker, an Id of the media is stored into Umbraco
     /// This Converter converts an MediaId to the direct url of the image
@@ -17,57 +14,112 @@ namespace Umbraco.Inception.Converters
     /// </summary>
     public class MediaIdConverter : TypeConverter
     {
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-        {
-            return (destinationType == typeof(string));
-        }
-
-        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
-        {
-            if (value == null) return -1;
-            string valueContent = value.ToString();
-            IMediaService ms = ConverterHelper.GetMediaService();
-            IMedia media = ms.GetMediaByPath(valueContent);
-            if (media != null) return media.Id;
-            return -1;
-        }
-
+        /// <summary>
+        /// Returns whether this converter can convert an object of the given type to the type of this converter, using the specified context.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="sourceType">A <see cref="T:System.Type" /> that represents the type you want to convert from.</param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
-            return (sourceType != typeof(string));
+            if (sourceType == typeof(string))
+            {
+                return true;
+            }
+
+            // Always call the base to see if it can perform the conversion. 
+            return base.CanConvertFrom(context, sourceType);
         }
 
+        /// <summary>
+        /// Converts the given object to the type of this converter, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
         public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
         {
-            if (value == null) return null;
-            int mediaId;
-            if (int.TryParse(value.ToString(), out mediaId))
+            if (value != null)
             {
-                if (mediaId < 1) return null;
-
-                var umbracoHelper = ConverterHelper.GetUmbracoHelper();
-                try
+                int mediaId;
+                if (int.TryParse(value.ToString(), out mediaId))
                 {
-                    IPublishedContent media = umbracoHelper.TypedMedia(mediaId);
-                    return media.Url;
-                }
-                catch (Exception ex)
-                {
-                    System.Diagnostics.Debug.WriteLine(ex.Message);
-                    try
+                    if (mediaId > 0)
                     {
-                        var ms = ConverterHelper.GetMediaService();
-                        IMedia media = ms.GetById(mediaId);
-                        if (media != null) return media.GetValue("umbracoFile");
-                    }
-                    catch (Exception)
-                    {
-                        return null;
-                    }
-                }
+                        UmbracoHelper umbracoHelper = ConverterHelper.GetUmbracoHelper();
 
+                        IPublishedContent media = umbracoHelper.TypedMedia(mediaId);
+
+                        if (media != null)
+                        {
+                            return media.Url;
+                        }
+
+                        IMediaService mediaService = ConverterHelper.GetMediaService();
+                        IMedia media2 = mediaService.GetById(mediaId);
+
+                        if (media2 != null)
+                        {
+                            return media2.GetValue("umbracoFile");
+                        }
+                    }
+                }
             }
-            return null;
+
+            // Always call base, even if you can't convert. 
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        /// <summary>
+        /// Returns whether this converter can convert the object to the specified type, using the specified context.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="destinationType">A <see cref="T:System.Type" /> that represents the type you want to convert to.</param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(string))
+            {
+                return true;
+            }
+
+            // Always call the base to see if it can perform the conversion. 
+            return base.CanConvertTo(context, destinationType);
+        }
+
+        /// <summary>
+        /// Converts the given value object to the specified type, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">A <see cref="T:System.Globalization.CultureInfo" />. If null is passed, the current culture is assumed.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <param name="destinationType">The <see cref="T:System.Type" /> to convert the <paramref name="value" /> parameter to.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
+        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        {
+            if (value != null)
+            {
+                string valueContent = value.ToString();
+                IMediaService mediaService = ConverterHelper.GetMediaService();
+                IMedia media = mediaService.GetMediaByPath(valueContent);
+
+                if (media != null)
+                {
+                    return media.Id;
+                }
+            }
+
+            // Always call base, even if you can't convert. 
+            return base.ConvertTo(context, culture, value, destinationType);
         }
     }
 }

--- a/Umbraco.Inception/Converters/ModelConverter.cs
+++ b/Umbraco.Inception/Converters/ModelConverter.cs
@@ -1,58 +1,101 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Umbraco.Core.Models;
-using Umbraco.Web;
-using Umbraco.Inception.Extensions;
-using Umbraco.Inception.BL;
-
-
-namespace Umbraco.Inception.Converters
+﻿namespace Umbraco.Inception.Converters
 {
+    using System;
+    using System.ComponentModel;
+
+    using Umbraco.Core.Models;
+    using Umbraco.Inception.BL;
+    using Umbraco.Inception.Extensions;
+    using Umbraco.Web;
+
+    /// <summary>
+    /// The model converter.
+    /// </summary>
+    /// <typeparam name="T">The <see cref="T:System.Type"/> to convert to and from.</typeparam>
     public class ModelConverter<T> : TypeConverter
     {
+        /// <summary>
+        /// Returns whether this converter can convert an object of the given type to the type of this converter, using the specified context.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="sourceType">A <see cref="T:System.Type" /> that represents the type you want to convert from.</param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
-            return (sourceType == typeof(string));
+            if (sourceType == typeof(string))
+            {
+                return true;
+            }
+
+            // Always call the base to see if it can perform the conversion. 
+            return base.CanConvertFrom(context, sourceType);
         }
 
+        /// <summary>
+        /// Converts the given object to the type of this converter, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
         public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
         {
             int id;
             if (int.TryParse(value as string, out id))
             {
-                UmbracoHelper uh = ConverterHelper.GetUmbracoHelper();
-                IPublishedContent content = uh.TypedContent(id);
+                UmbracoHelper helper = ConverterHelper.GetUmbracoHelper();
+                IPublishedContent content = helper.TypedContent(id);
                 return content.ConvertToModel<T>();
             }
 
-            return null;
+            // Always call base, even if you can't convert. 
+            return base.ConvertFrom(context, culture, value);
         }
 
+        /// <summary>
+        /// Returns whether this converter can convert the object to the specified type, using the specified context.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="destinationType">A <see cref="T:System.Type" /> that represents the type you want to convert to.</param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
-            return (destinationType == typeof(T));
+            if (destinationType == typeof(T))
+            {
+                return true;
+            }
+
+            // Always call the base to see if it can perform the conversion. 
+            return base.CanConvertTo(context, destinationType);
         }
 
+        /// <summary>
+        /// Converts the given value object to the specified type, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">A <see cref="T:System.Globalization.CultureInfo" />. If null is passed, the current culture is assumed.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <param name="destinationType">The <see cref="T:System.Type" /> to convert the <paramref name="value" /> parameter to.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
         public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
         {
-            try
-            {
                 T target = (T)value;
                 UmbracoGeneratedBase baseObject = target as UmbracoGeneratedBase;
                 if (baseObject != null && baseObject.UmbracoId != null)
                 {
                     return baseObject.UmbracoId;
                 }
-                return -1;
-            }
-            catch (Exception ex)
-            {
-                throw ex;
-            }
+
+                // Always call base, even if you can't convert. 
+                return base.ConvertTo(context, culture, value, destinationType);
         }
     }
 }

--- a/Umbraco.Inception/Converters/MultipleMediaIdConverter.cs
+++ b/Umbraco.Inception/Converters/MultipleMediaIdConverter.cs
@@ -1,68 +1,117 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Umbraco.Core.Models;
-using Umbraco.Core.Services;
-
-namespace Umbraco.Inception.Converters
+﻿namespace Umbraco.Inception.Converters
 {
+    using System;
+    using System.ComponentModel;
+    using Umbraco.Core.Models;
+    using Umbraco.Core.Services;
+    using Umbraco.Web;
+
     /// <summary>
     /// Does the same as the MediaConverter but for the multiple MediaPicker
     /// </summary>
     public class MultipleMediaIdConverter : TypeConverter
     {
+        /// <summary>
+        /// Returns whether this converter can convert an object of the given type to the type of this converter, using the specified context.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="sourceType">A <see cref="T:System.Type" /> that represents the type you want to convert from.</param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
-            return (sourceType != typeof(string));
+            if (sourceType == typeof(string))
+            {
+                return true;
+            }
+
+            // Always call the base to see if it can perform the conversion. 
+            return base.CanConvertFrom(context, sourceType);
         }
 
+        /// <summary>
+        /// Converts the given object to the type of this converter, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
         public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
         {
-            if (value == null) return null;
-            string[] mediaIdArray = value.ToString().Split(',');
-            string[] mediaUrlArray = new string[mediaIdArray.Length];
-
-            for (int i = 0; i < mediaIdArray.Length; i++)
+            if (value != null)
             {
-                int mediaId;
+                string[] mediaIdArray = value.ToString().Split(',');
+                string[] mediaUrlArray = new string[mediaIdArray.Length];
 
-                if (int.TryParse(mediaIdArray[i], out mediaId))
+                for (int i = 0; i < mediaIdArray.Length; i++)
                 {
-                    if (mediaId < 1) return null;
+                    int mediaId;
 
-                    var umbracoHelper = ConverterHelper.GetUmbracoHelper();
-                    try
+                    if (int.TryParse(mediaIdArray[i], out mediaId))
                     {
-                        IPublishedContent media = umbracoHelper.TypedMedia(mediaId);
-                        mediaUrlArray[i] = media.Url;
+                        if (mediaId > 0)
+                        {
+                            UmbracoHelper umbracoHelper = ConverterHelper.GetUmbracoHelper();
+                            IPublishedContent media = umbracoHelper.TypedMedia(mediaId);
+                            mediaUrlArray[i] = media.Url;
+                        }
                     }
-                    catch (Exception ex)
-                    {
-                        System.Diagnostics.Debug.WriteLine(ex.Message);
-                        return null;
-                    }
+                }
+
+                return mediaUrlArray;
+            }
+
+            // Always call base, even if you can't convert. 
+            return base.ConvertFrom(context, culture, null);
+        }
+
+        /// <summary>
+        /// Returns whether this converter can convert the object to the specified type, using the specified context.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="destinationType">A <see cref="T:System.Type" /> that represents the type you want to convert to.</param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(string))
+            {
+                return true;
+            }
+
+            // Always call the base to see if it can perform the conversion. 
+            return base.CanConvertTo(context, destinationType);
+        }
+
+        /// <summary>
+        /// Converts the given value object to the specified type, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">A <see cref="T:System.Globalization.CultureInfo" />. If null is passed, the current culture is assumed.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <param name="destinationType">The <see cref="T:System.Type" /> to convert the <paramref name="value" /> parameter to.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
+        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        {
+            if (value != null)
+            {
+                string valueContent = value.ToString();
+                IMediaService mediaService = ConverterHelper.GetMediaService();
+                IMedia media = mediaService.GetMediaByPath(valueContent);
+                if (media != null)
+                {
+                    return media.Id;
                 }
             }
 
-            return mediaUrlArray;
-        }
-
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-        {
-            return (destinationType == typeof(string));
-        }
-
-        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
-        {
-            if (value == null) return -1;
-            string valueContent = value.ToString();
-            IMediaService ms = ConverterHelper.GetMediaService();
-            IMedia media = ms.GetMediaByPath(valueContent);
-            if (media != null) return media.Id;
-            return -1;
+            // Always call base, even if you can't convert. 
+            return base.ConvertTo(context, culture, value, destinationType);
         }
     }
 }

--- a/Umbraco.Inception/Converters/MultipleMediaIdConverter.cs
+++ b/Umbraco.Inception/Converters/MultipleMediaIdConverter.cs
@@ -14,21 +14,6 @@ namespace Umbraco.Inception.Converters
     /// </summary>
     public class MultipleMediaIdConverter : TypeConverter
     {
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-        {
-            return (destinationType == typeof(string));
-        }
-
-        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
-        {
-            if (value == null) return -1;
-            string valueContent = value.ToString();
-            IMediaService ms = ConverterHelper.GetMediaService();
-            IMedia media = ms.GetMediaByPath(valueContent);
-            if (media != null) return media.Id;
-            return -1;
-        }
-
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
             return (sourceType != typeof(string));
@@ -63,6 +48,21 @@ namespace Umbraco.Inception.Converters
             }
 
             return mediaUrlArray;
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return (destinationType == typeof(string));
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        {
+            if (value == null) return -1;
+            string valueContent = value.ToString();
+            IMediaService ms = ConverterHelper.GetMediaService();
+            IMedia media = ms.GetMediaByPath(valueContent);
+            if (media != null) return media.Id;
+            return -1;
         }
     }
 }

--- a/Umbraco.Inception/Converters/UBooleanConverter.cs
+++ b/Umbraco.Inception/Converters/UBooleanConverter.cs
@@ -1,50 +1,103 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Umbraco.Inception.Converters
+﻿namespace Umbraco.Inception.Converters
 {
+    using System;
+    using System.ComponentModel;
+
     /// <summary>
     /// Umbraco saves bools as 1 & 0. This parser converts them to booleans
     /// </summary>
     public class UBooleanConverter : TypeConverter
     {
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-        {
-            return (destinationType == typeof(string));
-        }
-
-        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
-        {
-            bool parsedValue;
-            if (value == null) return -1;
-            if (bool.TryParse(value.ToString(), out parsedValue))
-            {
-                if (parsedValue == true) return 1;
-            }
-
-            return 0;
-        }
-
+        /// <summary>
+        /// Returns whether this converter can convert an object of the given type to the type of this converter, using the specified context.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="sourceType">A <see cref="T:System.Type" /> that represents the type you want to convert from.</param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
-            return (sourceType != typeof(string));
+            if (sourceType == typeof(string))
+            {
+                return true;
+            }
+
+            // Always call the base to see if it can perform the conversion. 
+            return base.CanConvertFrom(context, sourceType);
         }
 
+        /// <summary>
+        /// Converts the given object to the type of this converter, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
         public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
         {
-            if (value == null) return null;
-            bool parsedValue;
+            if (value == null)
+            {
+                return null;
+            }
 
+            bool parsedValue;
             if (bool.TryParse(value.ToString(), out parsedValue))
             {
                 return parsedValue;
             }
 
-            return null;
+            // Always call base, even if you can't convert. 
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        /// <summary>
+        /// Returns whether this converter can convert the object to the specified type, using the specified context.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="destinationType">A <see cref="T:System.Type" /> that represents the type you want to convert to.</param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(string))
+            {
+                return true;
+            }
+
+            // Always call the base to see if it can perform the conversion. 
+            return base.CanConvertTo(context, destinationType);
+        }
+
+        /// <summary>
+        /// Converts the given value object to the specified type, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">A <see cref="T:System.Globalization.CultureInfo" />. If null is passed, the current culture is assumed.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <param name="destinationType">The <see cref="T:System.Type" /> to convert the <paramref name="value" /> parameter to.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
+        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        {
+            if (value != null)
+            {
+                bool parsedValue;
+                if (bool.TryParse(value.ToString(), out parsedValue))
+                {
+                    if (parsedValue)
+                    {
+                        return 1;
+                    }
+                }
+            }
+
+            // Always call base, even if you can't convert. 
+            return base.ConvertTo(context, culture, value, destinationType);
         }
     }
 }

--- a/Umbraco.Inception/Converters/UDateTimeConverter.cs
+++ b/Umbraco.Inception/Converters/UDateTimeConverter.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Umbraco.Inception.Converters
+﻿namespace Umbraco.Inception.Converters
 {
+    using System;
+    using System.ComponentModel;
+
     /// <summary>
     /// Converts the datetime string to a date
     /// Convert back doesn't do anything with the dateTime value
@@ -14,30 +10,89 @@ namespace Umbraco.Inception.Converters
     /// </summary>
     public class UDateTimeConverter : TypeConverter
     {
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-        {
-            return (destinationType == typeof(string));
-        }
-
-        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
-        {
-            return value;
-        }
-
+        /// <summary>
+        /// Returns whether this converter can convert an object of the given type to the type of this converter, using the specified context.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="sourceType">A <see cref="T:System.Type" /> that represents the type you want to convert from.</param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
-            return (sourceType != typeof(string));
+            if (sourceType == typeof(string))
+            {
+                return true;
+            }
+
+            // Always call the base to see if it can perform the conversion. 
+            return base.CanConvertFrom(context, sourceType);
         }
 
+        /// <summary>
+        /// Converts the given object to the type of this converter, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
         public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
         {
-            string valueContent = value.ToString();
-            DateTime dateTime;
-            if (DateTime.TryParse(valueContent, out dateTime))
+            if (value != null)
             {
-                return dateTime;
+                string valueContent = value.ToString();
+                DateTime dateTime;
+                if (DateTime.TryParse(valueContent, out dateTime))
+                {
+                    return dateTime;
+                }
             }
-            return null;
+
+            // Always call base, even if you can't convert. 
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        /// <summary>
+        /// Returns whether this converter can convert the object to the specified type, using the specified context.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="destinationType">A <see cref="T:System.Type" /> that represents the type you want to convert to.</param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(string))
+            {
+                return true;
+            }
+
+            // Always call the base to see if it can perform the conversion. 
+            return base.CanConvertTo(context, destinationType);
+        }
+
+        /// <summary>
+        /// Converts the given value object to the specified type, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">A <see cref="T:System.Globalization.CultureInfo" />. If null is passed, the current culture is assumed.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <param name="destinationType">The <see cref="T:System.Type" /> to convert the <paramref name="value" /> parameter to.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
+        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        {
+            // Umbraco knows how to store DateTime
+            if (value is DateTime)
+            {
+                return value;
+            }
+
+            // Always call base, even if you can't convert. 
+            return base.ConvertTo(context, culture, value, destinationType);
         }
     }
 }


### PR DESCRIPTION
The TypeConverters were not correctly implementing the base TypeConverter class. 

I've updated them to better match the example implementations on [MSDN](http://msdn.microsoft.com/en-us/library/ayybcxe5.aspx) and tested them briefly. (This project will need proper DB unit testing set up) and they seem to work. 

I would recommend that a proper testing mechanism would be set up before releasing new updates though. 
